### PR TITLE
Update CargoBay/CargoBay.m

### DIFF
--- a/CargoBay/CargoBay.m
+++ b/CargoBay/CargoBay.m
@@ -930,7 +930,7 @@ NSDictionary * CBPurchaseInfoFromTransactionReceipt(NSData *transactionReceiptDa
             return NO;
         }
     } else {
-        NSMutableDictionary *knownIAPTransactionsDictionary = [[NSUserDefaults standardUserDefaults] objectForKey:kCargoBayKnownIAPTransactionsKey];
+        NSMutableDictionary *knownIAPTransactionsDictionary = [[[NSUserDefaults standardUserDefaults] objectForKey:kCargoBayKnownIAPTransactionsKey] mutableCopy];
         if (!knownIAPTransactionsDictionary) {
             knownIAPTransactionsDictionary = [NSMutableDictionary dictionary];
         }


### PR DESCRIPTION
line 933 should need a mutableCopy, or line 939:

[knownIAPTransactionsDictionary setObject:[NSNumber numberWithBool:YES] forKey:transactionID];

throw exception in my test
