### PR TITLE
Example project is broken after updating AFNetworking

### DIFF
--- a/Example/CargoBay.xcodeproj/project.pbxproj
+++ b/Example/CargoBay.xcodeproj/project.pbxproj
@@ -25,16 +25,15 @@
 		F8AA37E615FD71F800C21309 /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = F8AA37E015FD71F800C21309 /* ViewController.m */; };
 		F8AA37EC15FD724E00C21309 /* CargoBay.m in Sources */ = {isa = PBXBuildFile; fileRef = F8AA37EB15FD724E00C21309 /* CargoBay.m */; };
 		F8AA37EF15FD747D00C21309 /* StoreKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8AA37EE15FD747D00C21309 /* StoreKit.framework */; };
-		F8AA380E15FD7A5300C21309 /* AFHTTPClient.m in Sources */ = {isa = PBXBuildFile; fileRef = F8AA37FA15FD7A5300C21309 /* AFHTTPClient.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		F8AA380F15FD7A5300C21309 /* AFHTTPRequestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = F8AA37FC15FD7A5300C21309 /* AFHTTPRequestOperation.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		F8AA381015FD7A5300C21309 /* AFImageRequestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = F8AA37FE15FD7A5300C21309 /* AFImageRequestOperation.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		F8AA381115FD7A5300C21309 /* AFJSONRequestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = F8AA380015FD7A5300C21309 /* AFJSONRequestOperation.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		F8AA381215FD7A5300C21309 /* AFJSONUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = F8AA380215FD7A5300C21309 /* AFJSONUtilities.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		F8AA381315FD7A5300C21309 /* AFNetworkActivityIndicatorManager.m in Sources */ = {isa = PBXBuildFile; fileRef = F8AA380415FD7A5300C21309 /* AFNetworkActivityIndicatorManager.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		F8AA381415FD7A5300C21309 /* AFPropertyListRequestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = F8AA380715FD7A5300C21309 /* AFPropertyListRequestOperation.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		F8AA381515FD7A5300C21309 /* AFURLConnectionOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = F8AA380915FD7A5300C21309 /* AFURLConnectionOperation.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		F8AA381615FD7A5300C21309 /* AFXMLRequestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = F8AA380B15FD7A5300C21309 /* AFXMLRequestOperation.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		F8AA381715FD7A5300C21309 /* UIImageView+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = F8AA380D15FD7A5300C21309 /* UIImageView+AFNetworking.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		F8AA380E15FD7A5300C21309 /* AFHTTPClient.m in Sources */ = {isa = PBXBuildFile; fileRef = F8AA37FA15FD7A5300C21309 /* AFHTTPClient.m */; };
+		F8AA380F15FD7A5300C21309 /* AFHTTPRequestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = F8AA37FC15FD7A5300C21309 /* AFHTTPRequestOperation.m */; };
+		F8AA381015FD7A5300C21309 /* AFImageRequestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = F8AA37FE15FD7A5300C21309 /* AFImageRequestOperation.m */; };
+		F8AA381115FD7A5300C21309 /* AFJSONRequestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = F8AA380015FD7A5300C21309 /* AFJSONRequestOperation.m */; };
+		F8AA381315FD7A5300C21309 /* AFNetworkActivityIndicatorManager.m in Sources */ = {isa = PBXBuildFile; fileRef = F8AA380415FD7A5300C21309 /* AFNetworkActivityIndicatorManager.m */; };
+		F8AA381415FD7A5300C21309 /* AFPropertyListRequestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = F8AA380715FD7A5300C21309 /* AFPropertyListRequestOperation.m */; };
+		F8AA381515FD7A5300C21309 /* AFURLConnectionOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = F8AA380915FD7A5300C21309 /* AFURLConnectionOperation.m */; };
+		F8AA381615FD7A5300C21309 /* AFXMLRequestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = F8AA380B15FD7A5300C21309 /* AFXMLRequestOperation.m */; };
+		F8AA381715FD7A5300C21309 /* UIImageView+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = F8AA380D15FD7A5300C21309 /* UIImageView+AFNetworking.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -82,8 +81,6 @@
 		F8AA37FE15FD7A5300C21309 /* AFImageRequestOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFImageRequestOperation.m; sourceTree = "<group>"; };
 		F8AA37FF15FD7A5300C21309 /* AFJSONRequestOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFJSONRequestOperation.h; sourceTree = "<group>"; };
 		F8AA380015FD7A5300C21309 /* AFJSONRequestOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFJSONRequestOperation.m; sourceTree = "<group>"; };
-		F8AA380115FD7A5300C21309 /* AFJSONUtilities.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFJSONUtilities.h; sourceTree = "<group>"; };
-		F8AA380215FD7A5300C21309 /* AFJSONUtilities.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFJSONUtilities.m; sourceTree = "<group>"; };
 		F8AA380315FD7A5300C21309 /* AFNetworkActivityIndicatorManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFNetworkActivityIndicatorManager.h; sourceTree = "<group>"; };
 		F8AA380415FD7A5300C21309 /* AFNetworkActivityIndicatorManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFNetworkActivityIndicatorManager.m; sourceTree = "<group>"; };
 		F8AA380515FD7A5300C21309 /* AFNetworking.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFNetworking.h; sourceTree = "<group>"; };
@@ -244,8 +241,6 @@
 				F8AA37FE15FD7A5300C21309 /* AFImageRequestOperation.m */,
 				F8AA37FF15FD7A5300C21309 /* AFJSONRequestOperation.h */,
 				F8AA380015FD7A5300C21309 /* AFJSONRequestOperation.m */,
-				F8AA380115FD7A5300C21309 /* AFJSONUtilities.h */,
-				F8AA380215FD7A5300C21309 /* AFJSONUtilities.m */,
 				F8AA380315FD7A5300C21309 /* AFNetworkActivityIndicatorManager.h */,
 				F8AA380415FD7A5300C21309 /* AFNetworkActivityIndicatorManager.m */,
 				F8AA380515FD7A5300C21309 /* AFNetworking.h */,
@@ -385,7 +380,6 @@
 				F8AA380F15FD7A5300C21309 /* AFHTTPRequestOperation.m in Sources */,
 				F8AA381015FD7A5300C21309 /* AFImageRequestOperation.m in Sources */,
 				F8AA381115FD7A5300C21309 /* AFJSONRequestOperation.m in Sources */,
-				F8AA381215FD7A5300C21309 /* AFJSONUtilities.m in Sources */,
 				F8AA381315FD7A5300C21309 /* AFNetworkActivityIndicatorManager.m in Sources */,
 				F8AA381415FD7A5300C21309 /* AFPropertyListRequestOperation.m in Sources */,
 				F8AA381515FD7A5300C21309 /* AFURLConnectionOperation.m in Sources */,


### PR DESCRIPTION
The example project doesn't compile after the AFNetworking submodule update. I fixed it and it compiles now.

I am not sure if the example ought to do anything though. On execution, it just loads a blank screen. And by looking at the code it doesn't seem to do anything apart from adding CargoBay as the transaction observer in the AppDelegate.
