### PR TITLE
Crash on non-zero-weak-reference systems

### DIFF
--- a/CargoBay/CargoBay.m
+++ b/CargoBay/CargoBay.m
@@ -1074,8 +1074,6 @@ restoreCompletedTransactionsFailedWithError:(NSError *)error
 
 #if __has_feature(objc_arc_weak)
     __weak __typeof(&*self)weakSelf = self;
-#else
-    __unsafe_unretained __typeof(&*self)weakSelf = self;
 #endif
 
     _success = [^(NSArray *products, NSArray *invalidIdentifiers) {
@@ -1083,7 +1081,9 @@ restoreCompletedTransactionsFailedWithError:(NSError *)error
             success(products, invalidIdentifiers);
         }
 
+#if __has_feature(objc_arc_weak)
         [[weakSelf class] unregisterDelegate:weakSelf];
+#endif
     } copy];
     
     _failure = [^(NSError *error) {
@@ -1091,7 +1091,9 @@ restoreCompletedTransactionsFailedWithError:(NSError *)error
             failure(error);
         }
         
+#if __has_feature(objc_arc_weak)
         [[weakSelf class] unregisterDelegate:weakSelf];
+#endif
     } copy];
     
     
@@ -1103,9 +1105,19 @@ restoreCompletedTransactionsFailedWithError:(NSError *)error
 - (void)request:(SKRequest *)request
 didFailWithError:(NSError *)error
 {
+#if !__has_feature(objc_arc_weak)
+    [[self class] unregisterDelegate:self];
+#endif
     if (_failure) {
         _failure(error);
     }    
+}
+
+- (void)requestDidFinish:(SKRequest *)request
+{
+#if !__has_feature(objc_arc_weak)
+    [[self class] unregisterDelegate:self];
+#endif
 }
 
 #pragma mark - SKProductsRequestDelegate


### PR DESCRIPTION
On iOS < 5, the requestDidFinish delegate method will be called on the delegate after it
has already been released by the system. This works fine with zeroing weak
references, where a method call on nil will simply be ignored.
This poses a problem, however, if the reference in question has never been
zeroed out, since requestDidFinish will effectively be called on a released object, causing an EXC_BAD_ACCESS crash. The solution is to only remove the delegate in requestDidFinish on non weak reference systems.
