### PR TITLE
Fixed rare crash when verifying transactions on iOS 5.1.1.

### DIFF
--- a/CargoBay/CargoBay.m
+++ b/CargoBay/CargoBay.m
@@ -599,7 +599,14 @@ NSDictionary * CBPurchaseInfoFromTransactionReceipt(NSData *transactionReceiptDa
     if (!transactionReceiptDictionary) {
         return nil;
     }
-    
+
+    // Fixes crash in iOS 5.1.1 (not sure if crash provoked by people trying to crack IAP
+    // or it is a legitimate iOS 5.1.1 crash). In any case CargoBay should just fail
+    // verification and not crash.
+    if ( ![transactionReceiptDictionary respondsToSelector:@selector(objectForKey:)] ) {
+        return nil;
+    }
+
     NSString *purchaseInfo = [transactionReceiptDictionary objectForKey:@"purchase-info"];
     NSDictionary *purchaseInfoDictionary = [NSPropertyListSerialization propertyListWithData:CBDataFromBase64EncodedString(purchaseInfo) options:NSPropertyListImmutable format:nil error:error];
     if (!purchaseInfoDictionary) {


### PR DESCRIPTION
Maybe this crash is caused by Jailbreak or by malicious users who try to crack IAPs.

I have not been able to repro it myself, but I have seen reports of it on my deployed App.

Some additional info from BugSense: 88 instances of this crash happened on 5.1.1, and 1 on 5.1.0. No idea why, maybe this is the only supported iOS version for IAP cracking? No other iOS version presents this crash.

It happens on all kind of devices: iPhones, iPads and iPod Touchs.

Partial stack trace:

0 CoreFoundation 0x3780488f **exceptionPreprocess + 162
1 libobjc.A.dylib 0x31879259 objc_exception_throw + 32
2 CoreFoundation 0x37807a9b -[NSObject doesNotRecognizeSelector:] + 174
3 CoreFoundation 0x37806915 ___forwarding_** + 300
4 CoreFoundation 0x37761650 _CF_forwarding_prep_0 + 48
5 MyApp CBPurchaseInfoFromTransactionReceipt (CargoBay.m:603) 0x0012b9fb _mh_execute_header + 203259
6 MyApp -[CargoBay isValidTransaction:error:](CargoBay.m:952) 0x0012d22b _mh_execute_header + 209451
7 MyApp -[CargoBay verifyTransaction:password:success:failure:](CargoBay.m:745) 0x0012c405 _mh_execute_header + 205829
8 MyApp -[CargoManager transactionUpdated:](CargoManager.m:188) 0x0011969d _mh_execute_header + 128669

I simply fixed by making sure that the transactionReceiptDictionary responds to selector objectForKey:. If not, I return nil from that method.
