### PR TITLE
Removed faulty iOS 7 transaction receipt

### DIFF
--- a/CargoBay/CargoBay.m
+++ b/CargoBay/CargoBay.m
@@ -585,13 +585,13 @@ _out:
 NSData * CBTransactionReceiptFromPaymentTransaction(SKPaymentTransaction *transaction) {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    if ([NSBundle instancesRespondToSelector:@selector(appStoreReceiptURL)]) {
-        NSError *error = nil;
-        NSData *data = [NSData dataWithContentsOfURL:[[NSBundle mainBundle] appStoreReceiptURL] options:0 error:&error];
-        if (data && !error) {
-            return data;
-        }
-    }
+    // if ([NSBundle instancesRespondToSelector:@selector(appStoreReceiptURL)]) {
+    //     NSError *error = nil;
+    //     NSData *data = [NSData dataWithContentsOfURL:[[NSBundle mainBundle] appStoreReceiptURL] options:0 error:&error];
+    //     if (data && !error) {
+    //         return data;
+    //     }
+    // }
 
     return transaction.transactionReceipt;
 #pragma clang diagnostic pop


### PR DESCRIPTION
The transaction receipt for iOS 7 is faulty as it is now (see these 2 issues - https://github.com/mattt/CargoBay/issues/55 - https://github.com/mattt/CargoBay/issues/52). 

I've removed the new way of getting the transaction receipt until a solution is found that works.
