### PR TITLE
Simplify CargoBayProductRequestDelegate init

### DIFF
--- a/CargoBay/CargoBay.m
+++ b/CargoBay/CargoBay.m
@@ -1080,18 +1080,9 @@ restoreCompletedTransactionsFailedWithError:(NSError *)error
         return nil;
     }
 
-    self.success = ^(NSArray *products, NSArray *invalidIdentifiers) {
-        if (success) {
-            success(products, invalidIdentifiers);
-        }
-    };
-    
-    self.failure = ^(NSError *error) {
-        if (failure) {
-            failure(error);
-        }
-    };
-    
+    self.success = success;
+    self.failure = failure;
+
     return self;
 }
 


### PR DESCRIPTION
Unless I’m missing something here, these blocks are `(copy)` properties, so I don’t see why we should redefine them. 

I understand we need to check if these blocks are nil before actually calling them, but this verification already exists where they are being used in `request:didFailWithError:` and `productsRequest:didReceiveResponse:`. So we’re checking twice, which seems unnecessarily redundant to me. 
