### PR TITLE
SKProductsRequest releasing too fast

### DIFF
--- a/CargoBay/CargoBay.m
+++ b/CargoBay/CargoBay.m
@@ -696,6 +696,11 @@ NSDictionary * CBPurchaseInfoFromTransactionReceipt(NSData *transactionReceiptDa
 
     [CargoBayProductRequestDelegate registerDelegate:delegate];
     [request start];
+    
+    // Fix request oject too fast relase
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(2 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        [request description];
+    });
 }
 
 - (void)productsWithRequest:(NSURLRequest *)urlRequest


### PR DESCRIPTION
I got an issue in my app that I can reproduce in AppStore and in Xcode. On first app launch everything works fine, but starting from second one there is no any callback from productsWithIdentifiers method.

The core of this issue is that SKProductsRequest deallocated before it started and not of any callbacks in CargoBayProductRequestDelegate never called. This issue also described on stackoverflow.

My fix is retain request object for 2 seconds. Works in debug with XCode and in AppStore released version.
