### PR TITLE
Add support for tvOS

### DIFF
--- a/CargoBay.podspec
+++ b/CargoBay.podspec
@@ -12,7 +12,9 @@ Pod::Spec.new do |s|
 
   s.ios.deployment_target = '6.0'
   s.osx.deployment_target = '10.8'
+  s.tvos.deployment_target = '9.0'
   s.frameworks = 'StoreKit', 'Security'
 
-  s.dependency 'AFNetworking', '~> 2.2'
+  s.dependency 'AFNetworking/NSURLSession', '~> 2.2'
+  s.dependency 'AFNetworking/NSURLConnection', '~> 2.2'
 end

--- a/CargoBay/CargoBay.m
+++ b/CargoBay/CargoBay.m
@@ -640,6 +640,9 @@ NSDictionary * CBPurchaseInfoFromTransactionReceipt(NSData *transactionReceiptDa
 @property (readwrite, nonatomic, copy) CargoBayPaymentQueueProductSuccessBlock success;
 @property (readwrite, nonatomic, copy) CargoBayPaymentQueueProductFailureBlock failure;
 
+// On tvOS we need to retain the request
+@property (readwrite, nonatomic, strong) SKProductsRequest *request;
+
 + (void)registerDelegate:(CargoBayProductRequestDelegate *)delegate;
 + (void)unregisterDelegate:(CargoBayProductRequestDelegate *)delegate;
 
@@ -699,8 +702,9 @@ NSDictionary * CBPurchaseInfoFromTransactionReceipt(NSData *transactionReceiptDa
 {
     SKProductsRequest *request = [[SKProductsRequest alloc] initWithProductIdentifiers:identifiers];
 
-    id <SKProductsRequestDelegate> delegate = [[CargoBayProductRequestDelegate alloc] initWithSuccess:success failure:failure];
+    CargoBayProductRequestDelegate *delegate = [[CargoBayProductRequestDelegate alloc] initWithSuccess:success failure:failure];
     request.delegate = delegate;
+    delegate.request = request; // We need to retain the request on tvOS
 
     [CargoBayProductRequestDelegate registerDelegate:delegate];
     [request start];


### PR DESCRIPTION
This PR does 3 things:
- Adds support for tvOS in the podspec
- Replaces the dependency with `AFNetworking` with the dependencies to the specific subspecs needed by CargoBay (otherwise it would also depend on `AFNetworking/UIKit` which won't build for tvOS).
- Retains the `SKProductsRequest`: for some reason, `SKProductsRequest` are automatically deallocated on tvOS if they're not retained, compared to iOS where it's retained (presumably by some class of `StoreKit`).
