### PR TITLE
SKPaymentTransactionObserver: Continue App Store purchase

### DIFF
--- a/CargoBay/CargoBay.h
+++ b/CargoBay/CargoBay.h
@@ -169,6 +169,16 @@
  */
 - (void)setPaymentQueueUpdatedDownloadsBlock:(void (^)(SKPaymentQueue *queue, NSArray *downloads))block;
 
+
+/**
+ Sets a block to be called when the payment has requested directly via the App Store.
+
+ @param block A block object to be executed when the payment queue should decide to complete a transaction now, or defer it later.
+ 
+ @discussion Return NO to defer the payment to a later time, or YES to handle the payment now.  If deferred to a later time, you are responsible for keeping track of the payment object to handle it later.
+ */
+- (void)setPaymentQueueShouldAddStorePayment:(BOOL (^)(SKPaymentQueue *queue, SKPayment *payment, SKProduct *product))block;
+
 @end
 
 ///----------------

--- a/CargoBay/CargoBay.m
+++ b/CargoBay/CargoBay.m
@@ -41,6 +41,7 @@ typedef void (^CargoBayPaymentQueueRestoreSuccessBlock)(SKPaymentQueue *queue);
 typedef void (^CargoBayPaymentQueueRestoreFailureBlock)(SKPaymentQueue *queue, NSError *error);
 typedef void (^CargoBayPaymentQueueUpdatedDownloadsBlock)(SKPaymentQueue *queue, NSArray *downloads);
 typedef BOOL (^CargoBayTransactionIDUniquenessVerificationBlock)(NSString *transactionID);
+typedef BOOL (^CargoBayPaymentQueueShouldAddStorePaymentBlock)(SKPaymentQueue *queue, SKPayment *payment, SKProduct *product);
 
 extern NSDate * CBDateFromDateString(NSString *);
 extern NSString * CBBase64EncodedStringFromData(NSData *);
@@ -657,6 +658,7 @@ NSDictionary * CBPurchaseInfoFromTransactionReceipt(NSData *transactionReceiptDa
 @property (readwrite, nonatomic, copy) CargoBayPaymentQueueRestoreFailureBlock paymentQueueRestoreFailure;
 @property (readwrite, nonatomic, copy) CargoBayPaymentQueueUpdatedDownloadsBlock paymentQueueUpdatedDownloads;
 @property (readwrite, nonatomic, copy) CargoBayTransactionIDUniquenessVerificationBlock transactionIDUniquenessVerificationBlock;
+@property (readwrite, nonatomic, copy) CargoBayPaymentQueueShouldAddStorePaymentBlock paymentQueueShouldAddStorePayment;
 @end
 
 @implementation CargoBay
@@ -949,6 +951,10 @@ NSDictionary * CBPurchaseInfoFromTransactionReceipt(NSData *transactionReceiptDa
     self.paymentQueueUpdatedDownloads = block;
 }
 
+- (void)setPaymentQueueShouldAddStorePayment:(BOOL (^)(SKPaymentQueue *queue, SKPayment *payment, SKProduct *product))block {
+    _paymentQueueShouldAddStorePayment = block;
+}
+
 #pragma mark - Receipt Verification
 
 - (BOOL)isValidTransaction:(SKPaymentTransaction *)transaction
@@ -1054,6 +1060,15 @@ restoreCompletedTransactionsFailedWithError:(NSError *)error
     if (self.paymentQueueRestoreFailure) {
         self.paymentQueueRestoreFailure(queue, error);
     }
+}
+
+- (BOOL)paymentQueue:(SKPaymentQueue *)queue shouldAddStorePayment:(SKPayment *)payment forProduct:(SKProduct *)product {
+    
+    if (self.paymentQueueShouldAddStorePayment) {
+        return self.paymentQueueShouldAddStorePayment(queue, payment, product);
+    }
+    
+    return NO;
 }
 
 @end


### PR DESCRIPTION
Implements the continue App Store transaction delegate method.

```- (BOOL)paymentQueue:(SKPaymentQueue *)queue shouldAddStorePayment:(SKPayment *)payment forProduct:(SKProduct *)product```

I followed the same pattern as the other delegate methods.

Let me know if I missed something.